### PR TITLE
several aspects brought from remind to remindStart

### DIFF
--- a/R/chooseFolder.R
+++ b/R/chooseFolder.R
@@ -1,45 +1,8 @@
 chooseFolder <- function(folder, title = "Please choose a folder") {
-  dirs <- NULL
-
-  # Detect all output folders containing fulldata.gdx or non_optimal.gdx
-  # For coupled runs please use the outcommented text block below
-
   dirs <- dirname(Sys.glob(file.path(folder, "*", "full.gms")))
-
   # DK: The following outcommented lines are specially made for listing results of coupled runs
   #runs <- findCoupledruns(folder)
   #dirs <- findIterations(runs,modelpath=folder,latest=TRUE)
   #dirs <- sub("./output/","",dirs)
-
-  dirs <- c("all", dirs)
-  cat("\n\n",title,":\n\n")
-  cat(paste(1:length(dirs), dirs, sep=": " ),sep="\n")
-  cat(paste(length(dirs)+1, "Search by the pattern.\n", sep=": "))
-  cat("\nNumber: ")
-  identifier <- get_line()
-  identifier <- strsplit(identifier,",")[[1]]
-  tmp <- NULL
-  for (i in 1:length(identifier)) {
-    if (length(strsplit(identifier,":")[[i]]) > 1) tmp <- c(tmp,as.numeric(strsplit(identifier,":")[[i]])[1]:as.numeric(strsplit(identifier,":")[[i]])[2])
-    else tmp <- c(tmp,as.numeric(identifier[i]))
-  }
-  identifier <- tmp
-  # PATTERN
-  if(length(identifier==1) && identifier==(length(dirs)+1)){
-    cat("\nInsert the search pattern or the regular expression: ")
-    pattern <- get_line()
-    id <- grep(pattern=pattern, dirs[-1])
-    # lists all chosen directories and ask for the confirmation of the made choice
-    cat("\n\nYou have chosen the following directories:\n")
-    cat(paste(1:length(id), dirs[id+1], sep=": "), sep="\n")
-    cat("\nAre you sure these are the right directories?(y/n): ")
-    answer <- get_line()
-    if(answer=="y"){
-      return(dirs[id+1])
-    } else chooseFolder(folder,title)
-    #
-  } else if(any(dirs[identifier] == "all")){
-    identifier <- 2:length(dirs)
-    return(dirs[identifier])
-  } else return(dirs[identifier])
+  return(chooseFromList(dirs, type = "folders", returnboolean = FALSE))
 }

--- a/R/chooseSlurmConfig.R
+++ b/R/chooseSlurmConfig.R
@@ -1,36 +1,37 @@
-chooseSlurmConfig <- function() {
-  cat(crayon::yellow("\nPlease choose the SLURM configuration for your submission:\n"))
+chooseSlurmConfig <- function(identifier = FALSE) {
+  if (! length(identifier) == 1 || ! identifier %in% paste(seq(1:16))) {
+    wasselected <- TRUE
+    cat(crayon::yellow("\nPlease choose the SLURM configuration for your submission:\n"))
 
-  cat(crayon::yellow("\nCurrent cluster utilization:\n"))
-  system("sclass")
-  cat("\n")
+    cat(crayon::yellow("\nCurrent cluster utilization:\n"))
+    system("sclass")
+    cat("\n")
 
-  cat(paste0(
-    crayon::yellow("Your options:\n"),
-    crayon::blue("    QOS             tasks per node   suitable for\n"),
-    crayon::blue("=======================================================================\n"),
-    crayon::green(" 1:"), " SLURM standby               12   nash H12             [recommended]\n",
-    crayon::green(" 2:"), " SLURM standby               13   nash H12 coupled\n",
-    crayon::green(" 3:"), " SLURM standby               16   nash H12+\n",
-    crayon::green(" 4:"), " SLURM standby                1   nash debug, testOneRegi, reporting\n",
-    crayon::blue("--------------------------------------------------------------\n"),
-    crayon::green(" 5:"), " SLURM priority              12   nash H12             [recommended]\n",
-    crayon::green(" 6:"), " SLURM priority              13   nash H12 coupled\n",
-    crayon::green(" 7:"), " SLURM priority              16   nash H12+\n",
-    crayon::green(" 8:"), " SLURM priority               1   nash debug, testOneRegi, reporting\n",
-    crayon::blue("--------------------------------------------------------------\n"),
-    crayon::green(" 9:"), " SLURM short                 12   nash H12\n",
-    crayon::green("10:"), " SLURM short                 16   nash H12+\n",
-    crayon::green("11:"), " SLURM short                  1   nash debug, testOneRegi, reporting\n",
-    crayon::green("12:"), " SLURM medium                 1   negishi\n",
-    crayon::green("13:"), " SLURM long                   1   negishi\n",
-    crayon::blue("=======================================================================\n"),
-    crayon::green("Number: ")
-  ))
-
-  identifier <- get_line()
-  identifier <- as.numeric(strsplit(identifier, ",")[[1]])
-  comp <- switch(identifier,
+    cat(paste0(
+      crayon::yellow("Your options:\n"),
+      crayon::blue("    QOS             tasks per node   suitable for\n"),
+      crayon::blue("=======================================================================\n"),
+      crayon::green(" 1:"), " SLURM standby               12   nash H12             [recommended]\n",
+      crayon::green(" 2:"), " SLURM standby               13   nash H12 coupled\n",
+      crayon::green(" 3:"), " SLURM standby               16   nash H12+\n",
+      crayon::green(" 4:"), " SLURM standby                1   nash debug, testOneRegi, reporting\n",
+      crayon::blue("--------------------------------------------------------------\n"),
+      crayon::green(" 5:"), " SLURM priority              12   nash H12             [recommended]\n",
+      crayon::green(" 6:"), " SLURM priority              13   nash H12 coupled\n",
+      crayon::green(" 7:"), " SLURM priority              16   nash H12+\n",
+      crayon::green(" 8:"), " SLURM priority               1   nash debug, testOneRegi, reporting\n",
+      crayon::blue("--------------------------------------------------------------\n"),
+      crayon::green(" 9:"), " SLURM short                 12   nash H12\n",
+      crayon::green("10:"), " SLURM short                 16   nash H12+\n",
+      crayon::green("11:"), " SLURM short                  1   nash debug, testOneRegi, reporting\n",
+      crayon::green("12:"), " SLURM medium                 1   negishi\n",
+      crayon::green("13:"), " SLURM long                   1   negishi\n",
+      crayon::blue("=======================================================================\n"),
+      crayon::green("Number: ")
+    ))
+    identifier <- strsplit(get_line(), ",")[[1]]
+  }
+  comp <- switch(as.numeric(identifier),
     "1" = "--qos=standby --nodes=1 --tasks-per-node=12", # SLURM standby  - task per node: 12 (nash H12) [recommended]
     "2" = "--qos=standby --nodes=1 --tasks-per-node=13", # SLURM standby  - task per node: 13 (nash H12 coupled)
     "3" = "--qos=standby --nodes=1 --tasks-per-node=16", # SLURM standby  - task per node: 16 (nash H12+)
@@ -48,11 +49,13 @@ chooseSlurmConfig <- function() {
     "15" = "--qos=medium --nodes=1 --tasks-per-node=16", # SLURM medium   - task per node: 16 (nash long calibration)
     "16" = "direct"
   )
-
   if (is.null(comp)) {
-    stop("This type is invalid. Please choose a valid type")
+    message("This type is invalid. Please choose a valid type!")
+    comp <- chooseSlurmConfig()
   }
-
+  if (! exists("wasselected")) {
+    message("   SLURM option ", identifier, " selected: ", gsub("--", "", comp))
+  }
   comp
 }
 

--- a/R/chooseSlurmConfig.R
+++ b/R/chooseSlurmConfig.R
@@ -1,6 +1,7 @@
 chooseSlurmConfig <- function(identifier = FALSE) {
-  if (! length(identifier) == 1 || ! identifier %in% paste(seq(1:16))) {
-    wasselected <- TRUE
+  wasUserSelected <- FALSE
+  if (length(identifier) != 1 || ! identifier %in% paste(seq(1:16))) {
+    wasUserSelected <- TRUE
     cat(crayon::yellow("\nPlease choose the SLURM configuration for your submission:\n"))
 
     cat(crayon::yellow("\nCurrent cluster utilization:\n"))
@@ -53,8 +54,8 @@ chooseSlurmConfig <- function(identifier = FALSE) {
     message("This type is invalid. Please choose a valid type!")
     comp <- chooseSlurmConfig()
   }
-  if (! exists("wasselected")) {
-    message("   SLURM option ", identifier, " selected: ", gsub("--", "", comp))
+  if (! wasUserSelected) {
+    message("   SLURM option ", identifier, " used: ", gsub("--", "", comp))
   }
   comp
 }

--- a/R/configureCfg.R
+++ b/R/configureCfg.R
@@ -26,7 +26,7 @@ configureCfg <- function(scen,
         cfg[[switchname]] <- scen[[switchname]]
       }
     }
-    if (cfg$slurmConfig %in% paste(seq(1:16))) cfg$slurmConfig <- choose_slurmConfig(identifier = cfg$slurmConfig)
+    if (cfg$slurmConfig %in% paste(seq(1:16))) cfg$slurmConfig <- chooseSlurmConfig(identifier = cfg$slurmConfig)
     if (cfg$slurmConfig %in% c(NA, "")) cfg$slurmConfig <- slurmConfig
 
     # Set description

--- a/R/configureCfg.R
+++ b/R/configureCfg.R
@@ -48,6 +48,9 @@ configureCfg <- function(scen,
       }
     }
 
+    if (userArgs$debug) {
+      cfg$slurmConfig       <- slurmConfig
+    }
 
     if (userArgs$testOneRegi) {
       cfg$gms$optimization  <- "testOneRegi"

--- a/R/configureCfg.R
+++ b/R/configureCfg.R
@@ -6,19 +6,9 @@ configureCfg <- function(scen,
                          job_ids = NULL) {
   source("config/default.cfg", local = TRUE)
   cfg$title <- ifelse(!is.null(row.names(scen)), row.names(scen), "default")
-  cfg$slurmConfig <- slurmConfig
   cfg$remind_folder <- getwd()
   cfg$gitInfo <- gitInfo
   cfg$logoption <- 2 # log output written to file
-
-
-  if (userArgs$testOneRegi) {
-    cfg$title <- "testOneRegi"
-    cfg$gms$optimization <- "testOneRegi"
-    cfg$output <- NA
-    cfg$results_folder <- "output/testOneRegi"
-    cfg$force_replace <- TRUE # delete existing Results directory
-  }
 
   # To console
   cat("\n", crayon::green(cfg$title), "\n")
@@ -31,10 +21,19 @@ configureCfg <- function(scen,
   # Configure cfg based on settings from csv if provided
   if (!is.null(userArgs$configFile)) {
     # Edit main model file, region settings and input data revision based on scenarios table, if cell non-empty
-    for (switchname in intersect(c("model", "regionmapping", "inputRevision"), names(scen))) {
+    for (switchname in intersect(c("model", "regionmapping", "inputRevision", "slurmConfig"), names(scen))) {
       if (!is.na(scen[[switchname]])) {
         cfg[[switchname]] <- scen[[switchname]]
       }
+    }
+    if (cfg$slurmConfig %in% paste(seq(1:16))) cfg$slurmConfig <- choose_slurmConfig(identifier = cfg$slurmConfig)
+    if (cfg$slurmConfig %in% c(NA, "")) cfg$slurmConfig <- slurmConfig
+
+    # Set description
+    if ("description" %in% names(scen) && ! is.na(scen[["description"]])) {
+      cfg$description <- gsub('"', '', scen[["description"]])
+    } else {
+      cfg$description <- paste0("REMIND run ", scen, " started by ", config.file, ".")
     }
 
     # Set reporting script
@@ -48,6 +47,22 @@ configureCfg <- function(scen,
         cfg$gms[[switchname]] <- scen[[switchname]]
       }
     }
+
+
+    if (userArgs$testOneRegi) {
+      cfg$gms$optimization  <- "testOneRegi"
+      cfg$output            <- NA
+      cfg$description       <- paste("testOneRegi:", cfg$description)
+      cfg$slurmConfig       <- slurmConfig
+      if(is.null(userArgs$configFile)) {
+        cfg$title <- "testOneRegi"
+        cfg$results_folder  <- "output/testOneRegi"
+        cfg$force_replace   <- TRUE # delete existing Results directory
+        cfg$description     <- "A REMIND run using testOneRegi"
+      }
+    }
+
+    if (userArgs$debug) cfg$gms$cm_nash_mode <- "debug"
 
     gdxlist <- c(
       input.gdx = scen[["path_gdx"]],

--- a/R/handleArgs.R
+++ b/R/handleArgs.R
@@ -1,4 +1,4 @@
-handleArgs <- function(remind, configFile, restart, testOneRegi) {
+handleArgs <- function(remind, configFile, debug, interactive, restart, test, testOneRegi) {
   # Check for command-line arguments
   a <- R.utils::commandArgs(trailingOnly = TRUE)
   if (!(is.null(a) || identical(a, "--args"))) {
@@ -8,14 +8,17 @@ handleArgs <- function(remind, configFile, restart, testOneRegi) {
     a <- a[a != "--args"]
     for (i in a) {
       if (i == "--testOneRegi") testOneRegi <- TRUE
+      else if (i == "--test") test <- TRUE
+      else if (i == "--debug") debug <- TRUE
+      else if (i == "--interactive") interactive <- TRUE
       else if (i == "--restart") restart <- TRUE
       else if (file.exists(i) && (is.null(configFile) || configFile == i)) configFile <- i
       else abort("User error: unknown command line argument or file path. \\
-               Possible arguments are '--restart', '--testOneRegi'.")
+               Possible arguments are '--debug', '--interactive', '--restart', '--testOneRegi', '--test'.")
     }
   }
 
-  checkUserArguments(remind, configFile, restart, testOneRegi)
+  checkUserArguments(remind, configFile, restart, testOneRegi, debug, test, interactive)
 
   # Make paths absolute
   remind <- normalizePath(remind)
@@ -26,10 +29,13 @@ handleArgs <- function(remind, configFile, restart, testOneRegi) {
   list("remind" = remind,
        "configFile" = configFile,
        "testOneRegi" = testOneRegi,
-       "restart" = restart)
+       "restart" = restart,
+       "debug" = debug,
+       "interactive" = interactive,
+       "test" = test)
 }
 
-checkUserArguments <- function(remind, configFile, restart, testOneRegi) {
+checkUserArguments <- function(remind, configFile, restart, testOneRegi, debug, test, interactive) {
   if (!all(c("config", "core", "modules", "scripts", "standalone", "tutorials") %in% dir(remind))) {
     abort("Bad remind argument. Does not point to a remind directory.")
   }
@@ -46,8 +52,20 @@ checkUserArguments <- function(remind, configFile, restart, testOneRegi) {
     abort("Bad testOneRegi argument. Must be TRUE or FALSE.")
   }
 
+  if (!is.logical(test)) {
+    abort("Bad test argument. Must be TRUE or FALSE.")
+  }
+
+  if (!is.logical(debug)) {
+    abort("Bad debug argument. Must be TRUE or FALSE.")
+  }
+
+  if (!is.logical(interactive)) {
+    abort("Bad interactive argument. Must be TRUE or FALSE.")
+  }
+
   # Check for incompatibilities
-  if ((testOneRegi && !is.null(configFile)) || (restart && !is.null(configFile)) || (restart && testOneRegi)) {
+  if (restart && !is.null(configFile)) {
     abort("Arguments are incompatible.")
   }
 

--- a/R/handleArgs.R
+++ b/R/handleArgs.R
@@ -6,6 +6,15 @@ handleArgs <- function(remind, configFile, debug, interactive, restart, test, te
     # conflict with command-line arguments, throw an error.
     # Remove --args (i.e. the flag to signal that what comes after are the arguments)
     a <- a[a != "--args"]
+    # define arguments that are accepted with their shortcuts
+    accepted <- c("1" = "--testOneRegi", d = "--debug", i = "--interactive", r = "--restart", R = "--reprepare", t = "--test")
+    # search for strings that look like -i1asrR and transform them into long flags
+    onedashflags <- unlist(strsplit(paste0(a[grepl("^-[a-zA-Z0-9]*$", a)], collapse = ""), split = ""))
+    a <- unique(c(a[! grepl("^-[a-zA-Z0-9]*$", a)], unlist(accepted[names(accepted) %in% onedashflags])))
+    if (sum(! onedashflags %in% c(names(accepted), "-")) > 0) {
+      abort("User error: Unknown single character flags: ", onedashflags[! onedashflags %in% c(names(accepted), "-")],
+           ". Only available: ", paste0("-", names(accepted), collapse = ", ") )
+    }
     for (i in a) {
       if (i == "--testOneRegi") testOneRegi <- TRUE
       else if (i == "--test") test <- TRUE

--- a/R/read_scenario_cfg.R
+++ b/R/read_scenario_cfg.R
@@ -1,4 +1,4 @@
-read_scenario_cfg <- function(configFile, default.cfg = file.path(dirname(configFile), "default.cfg")) {
+read_scenario_cfg <- function(configFile, default.cfg = file.path(dirname(configFile), "default.cfg"), interactive = FALSE) {
   # Read-in the switches table, use first column as row names
   settings <- utils::read.csv2(configFile, stringsAsFactors = FALSE, row.names = 1, comment.char = "#", na.strings = "")
 
@@ -34,6 +34,7 @@ read_scenario_cfg <- function(configFile, default.cfg = file.path(dirname(config
   }
 
   # Perform checks on scenarios that are flagged to start
+  if(interactive) settings$start <- chooseFromList(rownames(settings), type = "runs", returnboolean = TRUE)
   scenarios <- settings[settings$start == 1, ]
 
   # Make sure scenario names don't includes a "."

--- a/R/restart.R
+++ b/R/restart.R
@@ -1,5 +1,5 @@
 # If restarting runs, then choose the folders and start runs
-restartRemind <- function(remind) {
+restartRemind <- function(remind, debug, test, testOneRegi) {
   # Get path to output folder
   of <- file.path(remind, "output")
 
@@ -15,13 +15,18 @@ restartRemind <- function(remind) {
     # Overwrite results_folder in cfg with name of the folder the user wants to restart,
     # because user might have renamed the folder before restarting
     cfg$results_folder <- i # nolint
-
-    if (slurmIsAvailable()) {
-      # Update the slurmConfig setting to what the user chooses
-      cfg$slurmConfig <- combineSlurmConfig(cfg$slurmConfig, chooseSlurmConfig())
-      submitRemindRun(cfg)
+    if (testOneRegi) cfg$gms$optimization <- "testOneRegi"
+    if (debug)       cfg$gms$cm_nash_mode <- "debug"
+    if (test) {
+      cli::cli_alert_info("If this wasn't --test mode, I would restart the model now.")
     } else {
-      withr::with_dir(cfg$results_folder, run())
+      if (slurmIsAvailable()) {
+        # Update the slurmConfig setting to what the user chooses
+        cfg$slurmConfig <- combineSlurmConfig(cfg$slurmConfig, chooseSlurmConfig())
+        submitRemindRun(cfg)
+      } else {
+        withr::with_dir(cfg$results_folder, run())
+      }
     }
   }
 }

--- a/R/start.R
+++ b/R/start.R
@@ -7,6 +7,9 @@
 #' @param configFile NULL or a character vector with the path to a scenario config csv file.
 #' @param restart TRUE or FALSE
 #' @param testOneRegi TRUE or FALSE
+#' @param debug TRUE or FALSE
+#' @param test TRUE or FALSE
+#' @param interactive TRUE or FALSE
 #'
 #' @export
 #'
@@ -23,10 +26,10 @@
 #' # Start from the command line
 #' Rscript -e "remindStart::start()" --args config/my_config.csv
 #' }
-start <- function(remind = ".", configFile = NULL, restart = FALSE, testOneRegi = FALSE) {
+start <- function(remind = ".", configFile = NULL, debug = FALSE, interactive = FALSE, restart = FALSE, test = FALSE, testOneRegi = FALSE) {
   # Take into account that this function may be called from the command-line directly, and that the command-line
   # arguments may overwrite the default/given function arguments.
-  userArgs <- handleArgs(normalizePath(remind), configFile, restart, testOneRegi)
+  userArgs <- handleArgs(normalizePath(remind), configFile, debug, interactive, restart, test, testOneRegi)
   invisible(list2env(userArgs, environment()))
   cli::cli_alert_success("Starting REMIND found at {remind}")
 
@@ -40,7 +43,7 @@ start <- function(remind = ".", configFile = NULL, restart = FALSE, testOneRegi 
 
   # If desired, restart existing REMIND runs. Then stop quietly.
   if (restart) {
-    restartRemind(remind)
+    restartRemind(remind, debug, test, testOneRegi)
     withr::with_options(list(show.error.messages = FALSE), stop())
   }
 
@@ -48,10 +51,13 @@ start <- function(remind = ".", configFile = NULL, restart = FALSE, testOneRegi 
   # is returned.
   if (!is.null(configFile)) {
     cli::cli_progress_step("Reading {configFile}", "Starting REMIND runs configured with: {configFile}")
-    scenarios <- read_scenario_cfg(configFile)
+    scenarios <- read_scenario_cfg(configFile, debug, interactive, testOneRegi)
     cli::cli_progress_done()
   } else {
-    scenarios <- data.frame("default" = "default", row.names = "default")
+    if (! testOneRegi)
+      scenarios <- data.frame("testOneRegi" = "testOneRegi", row.names = "testOneRegi")
+    else
+      scenarios <- data.frame("default" = "default", row.names = "default")
     cli::cli_alert_success("Starting REMIND run configured with: {remind}/config/default.cfg")
   }
 
@@ -65,12 +71,15 @@ start <- function(remind = ".", configFile = NULL, restart = FALSE, testOneRegi 
   cli::cli_progress_done()
 
   # If possible, submit scenarios to SLURM. Otherwise run sequentially in active R-session.
-  if (slurmIsAvailable()) {
-    cli::cli_alert_info("Submitting runs to slurm:")
-    submitScenariosToSlurm(userArgs, scenarios, gitInfo, baseCopy)
-  } else {
-    cli::cli_alert_info("Running remind.")
-    runLocally(userArgs, scenarios, gitInfo, baseCopy)
-    unlink(baseCopy, recursive = TRUE)
+  if (test) cli::cli_alert_info("If this wasn't --test mode, I would start/submit the model now.")
+  else {
+    if (slurmIsAvailable()) {
+      cli::cli_alert_info("Submitting runs to slurm:")
+      submitScenariosToSlurm(userArgs, scenarios, gitInfo, baseCopy)
+    } else {
+      cli::cli_alert_info("Running remind.")
+      runLocally(userArgs, scenarios, gitInfo, baseCopy)
+      unlink(baseCopy, recursive = TRUE)
+    }
   }
 }

--- a/R/start.R
+++ b/R/start.R
@@ -51,7 +51,7 @@ start <- function(remind = ".", configFile = NULL, debug = FALSE, interactive = 
   # is returned.
   if (!is.null(configFile)) {
     cli::cli_progress_step("Reading {configFile}", "Starting REMIND runs configured with: {configFile}")
-    scenarios <- read_scenario_cfg(configFile, debug, interactive, testOneRegi)
+    scenarios <- read_scenario_cfg(configFile, interactive)
     cli::cli_progress_done()
   } else {
     if (! testOneRegi)

--- a/R/utils.R
+++ b/R/utils.R
@@ -71,6 +71,47 @@ copyFromList <- function(filelist, destfolder) {
   }
 }
 
+chooseFromList <- function(thelist, type = "runs", returnboolean = FALSE) {
+  booleanlist <- numeric(length(thelist)) # set to zero
+  thelist <- c("all", thelist)
+  message("\n\nPlease choose ", type,":\n\n")
+  message(paste(paste(1:length(thelist), thelist, sep=": " ), collapse="\n"))
+  message(paste(length(thelist)+1, "Search by pattern...", sep=": "))
+  message("\nNumber: ")
+  identifier <- strsplit(get_line(), ",")[[1]]
+  tmp <- NULL
+  for (i in 1:length(identifier)) { # turns 2:5 into 2,3,4,5
+    if (length(strsplit(identifier,":")[[i]]) > 1) tmp <- c(tmp,as.numeric(strsplit(identifier,":")[[i]])[1]:as.numeric(strsplit(identifier,":")[[i]])[2])
+    else tmp <- c(tmp,as.numeric(identifier[i]))
+  }
+  identifier <- tmp
+  if (any(! identifier %in% seq(length(thelist)+1))) {
+    message("Try again, invalid choice: ", identifier)
+    return(chooseFromList(thelist[-1], type, returnboolean))
+  }
+  # PATTERN
+  if(length(identifier == 1) && identifier == (length(thelist)+1)){
+    message("\nInsert the search pattern or the regular expression: ")
+    pattern <- get_line()
+    id <- grep(pattern=pattern, thelist[-1])
+    # lists all chosen and ask for the confirmation of the made choice
+    message("\n\nYou have chosen the following ", type, ":")
+    message(paste(paste(1:length(id), thelist[id+1], sep=": "), collapse="\n"))
+    message("\nAre you sure these are the right ", type, "? (y/n): ")
+    if(get_line() == "y"){
+      identifier <- id+1
+      booleanlist[id] <- 1
+    } else {
+      return(chooseFromList(thelist[-1], type, returnboolean))
+    }
+  } else if(any(thelist[identifier] == "all")){
+    booleanlist[] <- 1
+    identifier <- 2:length(thelist)
+  } else {
+    booleanlist[identifier-1] <- 1
+  }
+  if (returnboolean) return(booleanlist) else return(thelist[identifier])
+}
 
 slurmIsAvailable <- function() {
   suppressWarnings(ifelse(system2("srun", stdout = FALSE, stderr = FALSE) != 127, TRUE, FALSE))

--- a/R/utils.R
+++ b/R/utils.R
@@ -71,47 +71,86 @@ copyFromList <- function(filelist, destfolder) {
   }
 }
 
-chooseFromList <- function(thelist, type = "runs", returnboolean = FALSE) {
-  booleanlist <- numeric(length(thelist)) # set to zero
-  thelist <- c("all", thelist)
+### chooseFromList
+# @param thelist: list to be selected from
+# @param group: list with same dimension as thelist with group names to allow to select whole groups
+# @param returnboolean: TRUE: returns list with dimension of thelist with 0 or 1. FALSE: returns selected entries of thelist
+# @param multiple: TRUE: allows to select multiple entries. FALSE: no
+# @param allowempty: TRUE: allows you not to select anything (returns NA). FALSE: must select something
+# @param type: string to be shown to user to understand what he chooses
+
+chooseFromList <- function(thelist, type = "runs", returnboolean = FALSE, multiple = TRUE,
+                           allowempty = FALSE, group = FALSE) {
+  originallist <- thelist
+  booleanlist <- numeric(length(originallist)) # set to zero
+  if (! isFALSE(group) && (length(group) != length(originallist) | isFALSE(multiple))) {
+    message("group must have same dimension as thelist, or multiple not allowed. Group mode disabled")
+    group <- FALSE
+  }
   message("\n\nPlease choose ", type,":\n\n")
-  message(paste(paste(1:length(thelist), thelist, sep=": " ), collapse="\n"))
-  message(paste(length(thelist)+1, "Search by pattern...", sep=": "))
-  message("\nNumber: ")
+  if (! isFALSE(group)) {
+    groups <- sort(unique(group))
+    groupsids <- seq(length(originallist)+2, length(originallist)+length(groups)+1)
+    thelist <- c(paste0(str_pad(thelist, max(nchar(originallist)), side = "right"), " ", group), paste("Group:", groups))
+    message(str_pad("", max(nchar(originallist)) + nchar(length(thelist)+2)+2, side = "right"), " Group")
+  }
+  if(multiple)   thelist <- c("all", thelist, "Search by pattern...")
+  message(paste(paste(str_pad(1:length(thelist), nchar(length(thelist)), side = "left"), thelist, sep=": " ), collapse="\n"))
+  message("\nNumber", ifelse(multiple,"s entered as 2,4:6,9",""),
+          ifelse(allowempty, " or leave empty", ""), " (", type, "): ")
   identifier <- strsplit(get_line(), ",")[[1]]
+  if (allowempty & length(identifier) == 0) return(NA)
+  if (length(identifier) == 0 | ! all(grepl("^[0-9,:]*$", identifier))) {
+    message("Try again, you have to choose some numbers.")
+    return(chooseFromList(originallist, type, returnboolean, multiple, allowempty, group))
+  }
   tmp <- NULL
   for (i in 1:length(identifier)) { # turns 2:5 into 2,3,4,5
-    if (length(strsplit(identifier,":")[[i]]) > 1) tmp <- c(tmp,as.numeric(strsplit(identifier,":")[[i]])[1]:as.numeric(strsplit(identifier,":")[[i]])[2])
-    else tmp <- c(tmp,as.numeric(identifier[i]))
+    if (length(strsplit(identifier,":")[[i]]) > 1) {
+      tmp <- c(tmp,as.numeric(strsplit(identifier,":")[[i]])[1]:as.numeric(strsplit(identifier,":")[[i]])[2])
+    }
+    else {
+      tmp <- c(tmp,as.numeric(identifier[i]))
+    }
   }
   identifier <- tmp
-  if (any(! identifier %in% seq(length(thelist)+1))) {
-    message("Try again, invalid choice: ", identifier)
-    return(chooseFromList(thelist[-1], type, returnboolean))
+  if (! multiple & length(identifier) > 1) {
+    message("Try again, not in list or multiple chosen: ", paste(identifier, collapse = ", "))
+    return(chooseFromList(originallist, type, returnboolean, multiple, allowempty, group))
+  }
+  if (any(! identifier %in% seq(length(thelist)))) {
+    message("Try again, not all in list: ", paste(identifier, collapse = ", "))
+    return(chooseFromList(originallist, type, returnboolean, multiple, allowempty, group))
+  }
+  if (! isFALSE(group)) {
+    selectedgroups <- sub("^Group: ", "", thelist[intersect(identifier, groupsids)])
+    identifier <- unique(c(identifier[! identifier %in% groupsids], which(group %in% selectedgroups)+1))
   }
   # PATTERN
-  if(length(identifier == 1) && identifier == (length(thelist)+1)){
+  if(multiple && length(identifier == 1) && identifier == length(thelist) ){
     message("\nInsert the search pattern or the regular expression: ")
     pattern <- get_line()
-    id <- grep(pattern=pattern, thelist[-1])
+    id <- grep(pattern=pattern, originallist)
     # lists all chosen and ask for the confirmation of the made choice
     message("\n\nYou have chosen the following ", type, ":")
-    message(paste(paste(1:length(id), thelist[id+1], sep=": "), collapse="\n"))
+    if (length(id) > 0) message(paste(paste(1:length(id), originallist[id], sep=": "), collapse="\n"))
     message("\nAre you sure these are the right ", type, "? (y/n): ")
     if(get_line() == "y"){
-      identifier <- id+1
+      identifier <- id
       booleanlist[id] <- 1
     } else {
-      return(chooseFromList(thelist[-1], type, returnboolean))
+      return(chooseFromList(originallist, type, returnboolean, multiple, allowempty, group))
     }
   } else if(any(thelist[identifier] == "all")){
     booleanlist[] <- 1
-    identifier <- 2:length(thelist)
+    identifier <- 1:length(originallist)
   } else {
-    booleanlist[identifier-1] <- 1
+    if (multiple) identifier <- identifier - 1
+    booleanlist[identifier] <- 1
   }
-  if (returnboolean) return(booleanlist) else return(thelist[identifier])
+  if (returnboolean) return(booleanlist) else return(originallist[identifier])
 }
+
 
 slurmIsAvailable <- function() {
   suppressWarnings(ifelse(system2("srun", stdout = FALSE, stderr = FALSE) != 127, TRUE, FALSE))


### PR DESCRIPTION
- enable chooseSlurmConfig to be called with identifier
- allow slurmConfig to be supplied in scen_conf
- generalize chooseFolder to chooseFromList
- add --test flag where runs are not actually submitted (may still be improved)
- add --debug flag where runs are started in debug mode
- add --interactive flag where user can select the runs to be started from scenario_config file
- make --testOneRegi and --debug compatible with --restart

I did not really have time to test all that, but wanted first that you have a look at it, I'm still not completely understanding the structure of the package. 